### PR TITLE
Refactor names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # project specific
 logs/*.log
+logs/*.log.*
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/incubator/bootstrap_cli/__init__.py
+++ b/incubator/bootstrap_cli/__init__.py
@@ -7,4 +7,4 @@
 
 # keep manually in sync with pyproject.toml until the above approach is working in Docker too
 # TODO: 220327 pa: switching to gh-action supported semantic-versioning
-__version__ = "1.5.0"
+__version__ = "1.6.0"

--- a/incubator/bootstrap_cli/__main__.py
+++ b/incubator/bootstrap_cli/__main__.py
@@ -222,7 +222,7 @@ class BootstrapCore:
             self.delete_or_deprecate: Dict[str, Any] = self.config.delete_or_deprecate
         else:
             self.config: BootstrapDeployConfig = BootstrapDeployConfig.from_yaml(configpath)
-            self.group_bootstrap_dimensions: Dict[str, Any] = self.config.bootstrap
+            self.group_bootstrap_hierarchy: Dict[str, Any] = self.config.bootstrap
             self.aad_mapping_lookup: Dict[str, Any] = self.config.aad_mappings
 
         self.deployed: Dict[str, Any] = {}
@@ -275,7 +275,7 @@ class BootstrapCore:
         return action_dimensions["admin"][acl_admin_type]
 
     def get_group_config_by_name(self, group_core):
-        for group_ns, group_ns_config in self.group_bootstrap_dimensions.items():
+        for group_ns, group_ns_config in self.group_bootstrap_hierarchy.items():
             if group_core in group_ns_config:
                 return group_ns_config[group_core]
 
@@ -315,7 +315,7 @@ class BootstrapCore:
             raw_db_names[action].extend(
                 [
                     self.get_raw_dbs_name_template().format(group_core=group_core, raw_suffix=raw_suffix)
-                    for group_core, group_config in self.group_bootstrap_dimensions[group_ns].items()
+                    for group_core, group_config in self.group_bootstrap_hierarchy[group_ns].items()
                     for raw_suffix in BootstrapCore.RAW_SUFFIXES
                 ]
                 # adding the {group_ns}:{BootstrapCore.AGGREGATED_GROUP_NAME} rawdbs
@@ -332,7 +332,7 @@ class BootstrapCore:
                     [
                         self.get_raw_dbs_name_template().format(group_core=shared_access, raw_suffix=raw_suffix)
                         # and check the "shared_access" groups list (else [])
-                        for _, group_config in self.group_bootstrap_dimensions[group_ns].items()
+                        for _, group_config in self.group_bootstrap_hierarchy[group_ns].items()
                         for shared_access in group_config.get("shared_owner_access", [])
                         for raw_suffix in BootstrapCore.RAW_SUFFIXES
                     ]
@@ -341,7 +341,7 @@ class BootstrapCore:
                     [
                         self.get_raw_dbs_name_template().format(group_core=shared_access, raw_suffix=raw_suffix)
                         # and check the "shared_access" groups list (else [])
-                        for _, group_config in self.group_bootstrap_dimensions[group_ns].items()
+                        for _, group_config in self.group_bootstrap_hierarchy[group_ns].items()
                         for shared_access in group_config.get("shared_read_access", [])
                         for raw_suffix in BootstrapCore.RAW_SUFFIXES
                     ]
@@ -382,7 +382,7 @@ class BootstrapCore:
             dataset_names[action].extend(
                 [
                     self.get_dataset_name_template().format(group_core=group_core)
-                    for group_core, group_config in self.group_bootstrap_dimensions[group_ns].items()
+                    for group_core, group_config in self.group_bootstrap_hierarchy[group_ns].items()
                 ]
                 # adding the {group_ns}:{BootstrapCore.AGGREGATED_GROUP_NAME} dataset
                 + [  # noqa
@@ -397,7 +397,7 @@ class BootstrapCore:
                     [
                         self.get_dataset_name_template().format(group_core=shared_access)
                         # and check the "shared_access" groups list (else [])
-                        for _, group_config in self.group_bootstrap_dimensions[group_ns].items()
+                        for _, group_config in self.group_bootstrap_hierarchy[group_ns].items()
                         for shared_access in group_config.get("shared_owner_access", [])
                     ]
                 )
@@ -405,7 +405,7 @@ class BootstrapCore:
                     [
                         self.get_dataset_name_template().format(group_core=shared_access)
                         # and check the "shared_access" groups list (else [])
-                        for _, group_config in self.group_bootstrap_dimensions[group_ns].items()
+                        for _, group_config in self.group_bootstrap_hierarchy[group_ns].items()
                         for shared_access in group_config.get("shared_read_access", [])
                     ]
                 )
@@ -688,7 +688,7 @@ class BootstrapCore:
                 # "external_id": add_prefix_external_id(group_config.get("external_id")),
                 "external_id": group_core_config.get("external_id"),
             }
-            for group_ns, group_ns_config in self.group_bootstrap_dimensions.items()
+            for group_ns, group_ns_config in self.group_bootstrap_hierarchy.items()
             for group_core, group_core_config in group_ns_config.items()
         }
 
@@ -706,7 +706,7 @@ class BootstrapCore:
                     "external_id": f"{group_ns}:{BootstrapCore.AGGREGATED_GROUP_NAME}" if group_ns else BootstrapCore.AGGREGATED_GROUP_NAME,
                 }
                 # creating 'all' at group type level + top-level
-                for group_ns in list(self.group_bootstrap_dimensions.keys()) + [""]
+                for group_ns in list(self.group_bootstrap_hierarchy.keys()) + [""]
             }
         )
 
@@ -779,7 +779,7 @@ class BootstrapCore:
         target_raw_db_names = set(
             [
                 self.get_raw_dbs_name_template().format(group_core=group_core, raw_suffix=raw_suffix)
-                for group_ns, group_ns_config in self.group_bootstrap_dimensions.items()
+                for group_ns, group_ns_config in self.group_bootstrap_hierarchy.items()
                 for group_core, group_core_config in group_ns_config.items()
                 for raw_suffix in BootstrapCore.RAW_SUFFIXES
             ]
@@ -793,7 +793,7 @@ class BootstrapCore:
                     else BootstrapCore.AGGREGATED_GROUP_NAME, raw_suffix=raw_suffix
                 )
                 # creating allprojects at group type level + top-level
-                for group_ns in list(self.group_bootstrap_dimensions.keys()) + [""]
+                for group_ns in list(self.group_bootstrap_hierarchy.keys()) + [""]
                 for raw_suffix in BootstrapCore.RAW_SUFFIXES
             ]
         )
@@ -834,7 +834,7 @@ class BootstrapCore:
     def generate_groups(self):
         # permutate the combinations
         for action in ["read", "owner"]:  # action_dimensions w/o 'admin'
-            for group_ns, group_configs in self.group_bootstrap_dimensions.items():
+            for group_ns, group_configs in self.group_bootstrap_hierarchy.items():
                 for group_core, group_config in group_configs.items():
                     # group for each dedicated group-type id
                     self.process_group(action, group_ns, group_core)

--- a/incubator/bootstrap_cli/__main__.py
+++ b/incubator/bootstrap_cli/__main__.py
@@ -258,23 +258,12 @@ class BootstrapCore:
 
     @staticmethod
     def get_dataset_name_template():
-        # 211013 pa: remove env prefixes
-        # return f"{shared_global_config['env']}:" + "{group_core}:dataset"
         return "{group_core}:dataset"
 
     @staticmethod
     def get_raw_dbs_name_template():
-        # 211013 pa: remove env prefixes
-        # return f"{shared_global_config['env']}:" + "{group_core}:rawdb{raw_suffix}"
         return "{group_core}:rawdb{raw_suffix}"
 
-    # 211013 pa: remove env prefixes
-    # def add_prefix_external_id(external_id):
-    #     # only prefix dataset external id with environment if 'prefix_external_id flag' is set to true in the config
-    #     if prefix_external_id:
-    #         return f"{shared_global_config['env']}:{external_id}"
-    #     else:
-    #         return external_id
     @staticmethod
     def get_timestamp():
         return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -487,8 +476,7 @@ class BootstrapCore:
 
         # detail level like cdf:src:001:public:read
         if action and group_ns and group_core:
-            # group for each dedicated group-type id
-            # group_name_full_qualified = f"{shared_global_config['env']}:{group_core}:{action}"
+            # group for each dedicated group-core id
             group_name_full_qualified = f"{BootstrapCore.GROUP_NAME_PREFIX}{group_core}:{action}"
 
             [

--- a/incubator/bootstrap_cli/__main__.py
+++ b/incubator/bootstrap_cli/__main__.py
@@ -46,7 +46,7 @@ Changelog:
  * removed 'transformation' acl from 'acl_all_scope_only_types'
     as it now supports dataset scopes too!
  * refactor variable names to match the new documentation
-    1. group_types_dimensions > group_bootstrap_dimensions
+    1. group_types_dimensions > group_bootstrap_hierarchy
     2. group_type > group_ns (namespace: src, ca, uc)
     3. group_prefix > group_core (src:001:sap)
 

--- a/incubator/bootstrap_cli/__main__.py
+++ b/incubator/bootstrap_cli/__main__.py
@@ -213,8 +213,8 @@ class BootstrapCore:
 
     # Mark all auto-generated CDF Group names
     GROUP_NAME_PREFIX = "cdf:"
-    # TODO: configurable and switch to 'all'
-    AGGREGATED_GROUP_NAME = "allprojects" 
+    # TODO: make configurable and switch to 'all' as default
+    AGGREGATED_GROUP_NAME = "allprojects"
 
     def __init__(self, configpath: str, delete: bool = False):
         if delete:

--- a/incubator/bootstrap_cli/__main__.py
+++ b/incubator/bootstrap_cli/__main__.py
@@ -42,6 +42,7 @@ Changelog:
 220405 sd:
  * v1.5.0 added dry-run mode as global parameter for all commands
 220405 pa:
+ * v1.6.0
  * removed 'transformation' acl from 'acl_all_scope_only_types'
     as it now supports dataset scopes too!
  * refactor variable names to match the new documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "inso-bootstrap-cli"
 # keep manually in sync with __init__.py > __version__
-version = "1.5.0"
+version = "1.6.0"
 description = "A CLI to deploy a CDF Project to bootstrap CDF Groups scoped with Data Sets and RAW DBs"
 authors = ["Peter Arwanitis <peter.arwanitis@cognite.com>", "Tugce Ozgur Oztetik <tugce.oztetik@cognite.com>", "Sverre Dørheim <sverre.dorheim@cognite.com>"]
 license = "Apache-2.0"
@@ -14,7 +14,7 @@ packages = [
 
 [tool.black]
 line-length = 120
-target_version = ['py37']
+target_version = ['py39']
 include = '\.py$'
 
 [tool.isort]

--- a/tests/example/config-deploy-bootstrap.yml
+++ b/tests/example/config-deploy-bootstrap.yml
@@ -18,7 +18,7 @@ cognite: # kwargs to pass to the CogniteClient, Environment variable format: ${E
 
 logger:
   file:
-    path: .\logs\create-dev-logs.log
+    path: ./logs/create-dev-logs.log
     level: INFO
   console:
     level: INFO

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,13 +5,43 @@ import os, json
 def main():
     config_file = "tests/example/config-deploy-bootstrap.yml"
     bootstrap = BootstrapCore(config_file)
+    bootstrap.load_deployed_config_from_cdf()
+
+    print(bootstrap.deployed["datasets"])
 
     root_account='root'
-
     group_name, group_capabilities = bootstrap.generate_group_name_and_capabilities(
             root_account=root_account,
         )
+    # sort capabilities by key
     print(group_name, json.dumps(sorted(group_capabilities, key=lambda x: list(x.keys())[0]), indent=2))
+
+    print('='*80)
+
+    action='read'
+    group_ns = 'src'
+    group_core = 'src:001:sap'
+    group_name, group_capabilities = bootstrap.generate_group_name_and_capabilities(
+        action=action,
+        group_ns=group_ns,
+        group_core=group_core,
+        )
+
+    # sort capabilities by key
+    print(group_name, json.dumps(sorted(group_capabilities, key=lambda x: list(x.keys())[0]), indent=2))
+
+    print('='*80)
+
+    action='owner'
+    group_ns = 'src'
+    group_name, group_capabilities = bootstrap.generate_group_name_and_capabilities(
+        action=action,
+        group_ns=group_ns,
+        )
+
+    # sort capabilities by key
+    print(group_name, json.dumps(sorted(group_capabilities, key=lambda x: list(x.keys())[0]), indent=2))
+
 
 if __name__ == "__main__":
     # dotenv_path = "/home/arwapet/.config/cdf/equinor-dev.env"


### PR DESCRIPTION
- fixed a forgotten interface still having the `dry_run` parameter
-  removed 'transformation' acl from `acl_all_scope_only_types`
    as it now supports dataset scopes too!
- refactor variable names to match the new documentation
   1. `group_types_dimensions` > `group_bootstrap_hierarchy`
   2. `group_type` > `group_ns` (**namespace**: src, ca, uc)
   3. `group_prefix` > `group_core` (src:001:sap)
- working on a test-config `tests/example/config-deploy-bootstrap.yml`