### PR TITLE
feat: adding --with-raw-capability flag

### DIFF
--- a/POETRY_ON_WINDOWS.md
+++ b/POETRY_ON_WINDOWS.md
@@ -1,5 +1,7 @@
 ## 220420 Windows + PowerShell + Python(s) + Poetry - lessons learned
 
+- Added to Cognite internal "Python Develkoper Hub" documentation
+
 ### environment
 
 - using a non-elevated PowerShell on Windows 10/11
@@ -10,7 +12,7 @@
 
 - use `poetry` with support for different Python versions on Windows
 - the solution requires
-  - no `pipenv` and
+  - no `pyenv` and
   - only one (non python-version specific) path added to environment
 
 ### tl;dr summary of environment changes

--- a/README.md
+++ b/README.md
@@ -390,7 +390,8 @@ Options:
   --dotenv-path TEXT       Provide a relative or absolute path to an .env file
                            (for commandline usage only)
   --debug                  Print debug information
-  --dry-run [yes|no]       Output planned action while doing nothing
+  --dry-run [yes|no]       Only logging planned CDF API action while doing
+                           nothing. Defaults to 'no'
   -h, --help               Show this message and exit.
 
 Commands:
@@ -431,7 +432,7 @@ Usage: bootstrap-cli prepare [OPTIONS] [CONFIG_FILE]
   only required once per CDF Project.
 
 Options:
-  --aad-source-id TEXT  Provide the AAD Source ID to use for the
+  --aad-source-id TEXT  [required] Provide the AAD Source ID to use for the
                         'cdf:bootstrap' Group. Typically for a new project its
                         the one configured for the CDF Group named 'oidc-
                         admin-group'.  [required]
@@ -451,8 +452,10 @@ Usage: bootstrap-cli deploy [OPTIONS] [CONFIG_FILE]
 
 Options:
   --with-special-groups [yes|no]  Create special CDF Groups, which don't have
-                                  capabilities (extractions, transformations)
-  --with-raw-capability [yes|no]  Create RAW DBs and 'rawAcl' capability
+                                  capabilities (extractions, transformations).
+                                  Defaults to 'no'
+  --with-raw-capability [yes|no]  Create RAW DBs and 'rawAcl' capability.
+                                  Defaults to 'yes'
   -h, --help                      Show this message and exit.
 ```
 
@@ -482,8 +485,9 @@ Usage: bootstrap-cli diagram [OPTIONS] [CONFIG_FILE]
 
 Options:
   --markdown [yes|no]             Encapsulate Mermaid diagram in Markdown
-                                  syntax
-  --with-raw-capability [yes|no]  Create RAW DBs and 'rawAcl' capability
+                                  syntax. Defaults to 'no'
+  --with-raw-capability [yes|no]  Create RAW DBs and 'rawAcl' capability.
+                                  Defaults to 'yes'
   -h, --help                      Show this message and exit.
 ```
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Purpose:
         - [`bootstrap` section](#bootstrap-section)
       - [Configuration for `delete` command](#configuration-for-delete-command)
         - [`delete_or_deprecate` section](#delete_or_deprecate-section)
-- [Development / Contribute](#development-contribute)
+- [Development / Contribute](#development--contribute)
   - [semantic versioning](#semantic-versioning)
   - [to be done](#to-be-done)
 - [how to run](#how-to-run)
@@ -452,6 +452,7 @@ Usage: bootstrap-cli deploy [OPTIONS] [CONFIG_FILE]
 Options:
   --with-special-groups [yes|no]  Create special CDF Groups, which don't have
                                   capabilities (extractions, transformations)
+  --with-raw-capability [yes|no]  Create RAW DBs and 'rawAcl' capability
   -h, --help                      Show this message and exit.
 ```
 
@@ -480,8 +481,10 @@ Usage: bootstrap-cli diagram [OPTIONS] [CONFIG_FILE]
   Diagram mode used to document the given configuration as a Mermaid diagram
 
 Options:
-  --markdown [yes|no]  Encapsulate Mermaid diagram in Markdown syntax
-  -h, --help           Show this message and exit.
+  --markdown [yes|no]             Encapsulate Mermaid diagram in Markdown
+                                  syntax
+  --with-raw-capability [yes|no]  Create RAW DBs and 'rawAcl' capability
+  -h, --help                      Show this message and exit.
 ```
 ## Configuration
 

--- a/incubator/bootstrap_cli/__init__.py
+++ b/incubator/bootstrap_cli/__init__.py
@@ -7,4 +7,4 @@
 
 # keep manually in sync with pyproject.toml until the above approach is working in Docker too
 # TODO: 220419 pa: switched to gh-action semantic-versioning, but still requires manually update here
-__version__ = "1.9.2"
+__version__ = "1.10.0"

--- a/incubator/bootstrap_cli/__main__.py
+++ b/incubator/bootstrap_cli/__main__.py
@@ -51,16 +51,17 @@
 # 220406 pa/sd:
 #  * v1.7.0
 #  * added 'diagram' command which creates a Mermaid (diagram as code) output
-
 # 220406 pa:
 #  * v1.7.1
 #  * started to use '# fmt:skip' to save intended multiline formatted and indented code
 #    from black auto-format
-
+# 220420 pa:
+#  * v.1.9.2
+#  * fixed Poetry on Windows issues
 # 220422 pa:
 #  * v1.10.0
 #  *  issue #28 possibility to skip creation of RAW DBs
-#   * added '--with-raw-capability' parameter for 'deploy' and 'diagram' commands
+#  * added '--with-raw-capability' parameter for 'deploy' and 'diagram' commands
 
 import logging
 import time
@@ -1476,7 +1477,7 @@ class BootstrapCore:
     "--dry-run",
     default="no",
     type=click.Choice(["yes", "no"], case_sensitive=False),
-    help="Output planned action while doing nothing",
+    help="Only logging planned CDF API action while doing nothing." " Defaults to 'no'",
 )
 @click.pass_context
 def bootstrap_cli(
@@ -1534,7 +1535,7 @@ def bootstrap_cli(
     # is_flag=True,
     default="no",
     type=click.Choice(["yes", "no"], case_sensitive=False),
-    help="Create special CDF Groups, which don't have capabilities (extractions, transformations)",
+    help="Create special CDF Groups, which don't have capabilities (extractions, transformations). " "Defaults to 'no'",
 )
 @click.option(
     "--with-raw-capability",
@@ -1543,7 +1544,7 @@ def bootstrap_cli(
     # is_flag=True,
     default="yes",
     type=click.Choice(["yes", "no"], case_sensitive=False),
-    help="Create RAW DBs and 'rawAcl' capability",
+    help="Create RAW DBs and 'rawAcl' capability. " "Defaults to 'yes'",
 )
 @click.pass_obj
 def deploy(
@@ -1594,7 +1595,7 @@ def deploy(
 @click.option(
     "--aad-source-id",
     required=True,
-    help="Provide the AAD Source ID to use for the 'cdf:bootstrap' Group. "
+    help="[required] Provide the AAD Source ID to use for the 'cdf:bootstrap' Group. "
     "Typically for a new project its the one configured for the CDF Group named 'oidc-admin-group'.",
 )
 @click.pass_obj
@@ -1674,7 +1675,7 @@ def delete(
     "--markdown",
     default="no",
     type=click.Choice(["yes", "no"], case_sensitive=False),
-    help="Encapsulate Mermaid diagram in Markdown syntax",
+    help="Encapsulate Mermaid diagram in Markdown syntax. " "Defaults to 'no'",
 )
 @click.option(
     "--with-raw-capability",
@@ -1683,7 +1684,7 @@ def delete(
     # is_flag=True,
     default="yes",
     type=click.Choice(["yes", "no"], case_sensitive=False),
-    help="Create RAW DBs and 'rawAcl' capability",
+    help="Create RAW DBs and 'rawAcl' capability. " "Defaults to 'yes'",
 )
 @click.pass_obj
 def diagram(

--- a/incubator/bootstrap_cli/__main__.py
+++ b/incubator/bootstrap_cli/__main__.py
@@ -1268,7 +1268,10 @@ class BootstrapCore:
                 )  # fmt: skip
 
                 # add core and all scopes
+                # shared_action: [read|owner]
                 for shared_action, scope_ctx in scope_ctx_by_action.items():
+                    # scope_type: [raw|datasets]
+                    # scopes: List[str]
                     for scope_type, scopes in scope_ctx.items():
 
                         if not self.with_raw_capability and scope_type == "raw":
@@ -1279,8 +1282,12 @@ class BootstrapCore:
                             if scope_name not in scope_graph:
                                 node_type_cls = SubroutineNode if scope_type == "raw" else AssymetricNode
                                 scope_graph.elements.append(
-                                    node_type_cls(name=f"{scope_name}:{action}", short=scope_name, comments="")
-                                )
+                                    node_type_cls(
+                                        name=f"{scope_name}:{action}",
+                                        short=scope_name,
+                                        comments=""
+                                        )
+                                )  # fmt: skip
                             # link from src:001:sap to 'src:001:sap:rawdb'
                             edge_type_cls = Edge if shared_action == "owner" else DottedEdge
                             graph.edges.append(
@@ -1294,7 +1301,13 @@ class BootstrapCore:
 
             # namespace-level like cdf:src:all:read
             elif action and group_ns:
-                ns_cdf_graph.elements.append(Node(name=group_name, short=group_name, comments=""))
+                ns_cdf_graph.elements.append(
+                    Node(
+                        name=group_name,
+                        short=group_name,
+                        comments=""
+                        )
+                    )  # fmt: skip
 
                 # link from 'all' to 'src:all'
                 edge_type_cls = Edge if action == "owner" else DottedEdge


### PR DESCRIPTION
- for 'deploy' and 'diagram' command (so the parameter comes after the command)
- addressing issue #28 

examples
```bash
# with  global parameter dry-run
➟  poetry run bootstrap-cli --dry-run yes deploy --with-raw-capability no .local/config-simple.yml 
# deploy w/o raw
➟  poetry run bootstrap-cli deploy --with-raw-capability no .local/config-simple.yml 
# diagram w/o raw
➟  poetry run bootstrap-cli diagram --with-raw-capability no .local/config-simple.yml 
```