### PR TITLE
fix: Refactor deployed config caching

### DIFF
--- a/incubator/bootstrap_cli/__init__.py
+++ b/incubator/bootstrap_cli/__init__.py
@@ -7,4 +7,4 @@
 
 # keep manually in sync with pyproject.toml until the above approach is working in Docker too
 # TODO: 220419 pa: switched to gh-action semantic-versioning, but still requires manually update here
-__version__ = "2.0.1"
+__version__ = "2.0.3"

--- a/incubator/bootstrap_cli/__main__.py
+++ b/incubator/bootstrap_cli/__main__.py
@@ -83,14 +83,14 @@
 #    - renamed mermaid properties from 'name/short' to 'id_name/display'
 #  * documented config-deploy-example-v2.yml
 # 220511 pa: v2.0.0 release :)
-# 220728 pa: v2.0.3 release with replacing time.sleep() statements (which could fail to reload CDF resources)
+# 220728 pa: v2.0.3 release with replacing time.sleep() statements (which could fail to reload CDF resources in time)
 #     through active caching of CDF resource changes
 #     * the 'self.deployed' is now of type 'CogniteDeployedCache' with support to create, update or delete cache entries
 #     Potential problem fixed with DRY-RUN and 'delete' command
 #     * enhanced dry-run logging
 #     Removed chunks from dataset creation (already covered by SDK)
 #    * made the '--debug' flag working, which can now overwrite a INFO level from config-yaml :)
-#      trick was to use the root-logger as global '_logging' variable
+#      solution was to use the root-logger as global '_logging' variable
 #      as it is shared with extractor-utils 'LoggingConfig'
 
 #

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,7 +8,6 @@ from incubator.bootstrap_cli.__main__ import BootstrapCore
 def main():
     config_file = "tests/example/config-deploy-bootstrap.yml"
     bootstrap = BootstrapCore(config_file)
-    bootstrap.load_deployed_config_from_cdf()
 
     print(bootstrap.deployed["datasets"])
 


### PR DESCRIPTION
- mostly a code cleanup (i.e. removed explicit chunking as SDK handles it)
- lots of logs switched to debug-level (configure level in config yaml!, the `--debug` flag is not working)
- cleaned up dry-run logging and potentially fixed issues with `delete` and `prepare` command
- new `CogniteResourceCache` and `CogniteDeployedCache` to track deployed CDF resources
  - looks now like an overkill to replace the -- sometimes buggy -- `time.sleep()` and reload from CDF
- no feature changes so next version is v2.0.3
- and finally made the `--debug` flag working, which now can overwrite an `INFO` log-level for files and console in config-yaml
  - don't use it regularly as it logs a lot of groups and datasets details 