### PR TITLE
feat(acls): adding four more capabilities (acls)

### DIFF
--- a/incubator/bootstrap_cli/__init__.py
+++ b/incubator/bootstrap_cli/__init__.py
@@ -7,4 +7,4 @@
 
 # keep manually in sync with pyproject.toml until the above approach is working in Docker too
 # TODO: 220419 pa: switched to gh-action semantic-versioning, but still requires manually update here
-__version__ = "2.0.3"
+__version__ = "2.1.0"

--- a/incubator/bootstrap_cli/__main__.py
+++ b/incubator/bootstrap_cli/__main__.py
@@ -166,10 +166,14 @@ acl_all_scope_only_types = set(
     [
         "projects",
         "sessions",
-        "functions",
         "entitymatching",
+        "functions",
         "types",
         "threed",
+        "seismic",
+        "digitalTwin",
+        "geospatial",
+        "geospatialCrs",
     ]
 )
 # lookup of non-default actions per capability (acl) and role (owner/read/admin)
@@ -206,17 +210,21 @@ action_dimensions = {
 acl_default_types = [
     "assets",
     "datasets",
+    "digitalTwin",
     "entitymatching",
     "events",
     "extractionPipelines",
     "extractionRuns",
     "files",
     "functions",
+    "geospatial",
+    "geospatialCrs",
     "groups",
     "labels",
     "projects",
     "raw",
     "relationships",
+    "seismic",
     "sequences",
     "sessions",
     "timeSeries",


### PR DESCRIPTION
extending the capabilities (acls) list for read / owner roles:
- seismic
- digitalTwin
- geospatial
- geospatialCrs

(all added scopes only supports `all`-scope)