### PR TITLE
feat: version in __init__ and pyproject.toml now in sync

### DIFF
--- a/incubator/bootstrap_cli/__init__.py
+++ b/incubator/bootstrap_cli/__init__.py
@@ -7,4 +7,4 @@
 
 # keep manually in sync with pyproject.toml until the above approach is working in Docker too
 # TODO: 220419 pa: switched to gh-action semantic-versioning, but still requires manually update here
-__version__ = "2.3.0"
+__version__ = "2.4.0"


### PR DESCRIPTION
- seems to be in sync that SemVer can bump them in gh-action
- latest change in pyproject.toml tries to get both under automated semantic-versioning control
