### PR TITLE
feat: adding annotationsAcl support

### DIFF
--- a/incubator/bootstrap_cli/__init__.py
+++ b/incubator/bootstrap_cli/__init__.py
@@ -6,5 +6,6 @@
 # print(f'__version__: {__version__}')
 
 # keep manually in sync with pyproject.toml until the above approach is working in Docker too
-# TODO: 220419 pa: switched to gh-action semantic-versioning, but still requires manually update here
+# SOLVED: 220419 pa: switched to gh-action semantic-versioning, but still requires manually update here
+# 230301 pa: automated by adding it to pyproject.toml > [tool.semantic_release] > version_variable
 __version__ = "2.5.1"

--- a/incubator/bootstrap_cli/__main__.py
+++ b/incubator/bootstrap_cli/__main__.py
@@ -99,6 +99,9 @@
 #       which didn't took aggregated-node-levels into account.
 #       Like `src:all` or `all` (dependent on your features.aggregated-level-name)
 #       2nd fix adding `extractionConfigs` to the list of supported and scoped ACLs
+# 230316 pa: feature-release adding annotationsAcl
+#       supporting all actions, even if action:REVIEW seems not to be used atm
+#       and action:READ is implicit
 #
 # TODO:
 #
@@ -172,6 +175,7 @@ acl_all_scope_only_types = set(
     [
         "projects",
         "sessions",
+        "annotations",
         "entitymatching",
         "functions",
         "types",
@@ -190,6 +194,7 @@ acl_all_scope_only_types = set(
 action_dimensions = {
     # owner datasets might only need READ and OWNER
     "owner": {  # else ["READ","WRITE"]
+        "annotations": ["READ", "WRITE", "SUGGEST", "REVIEW"],
         "raw": ["READ", "WRITE", "LIST"],
         "datasets": ["READ", "OWNER"],
         "groups": ["LIST"],
@@ -219,6 +224,7 @@ action_dimensions = {
 #
 acl_default_types = [
     "assets",
+    "annotations",
     "dataModels",
     "dataModelInstances",
     "datasets",


### PR DESCRIPTION
- `annotationsAcl` is essential for P&ID contextualization
- supporting all actions
- even if `action:REVIEW` seems not to be used atm
- and `action:READ` is implicit

(another v2 feature release, before the v3 release is ready)