### PR TITLE
no release, only adding `on: pull_request` to ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 name: ci
 
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       version:
@@ -16,28 +17,4 @@ jobs:
     steps:
     - run: |
         echo "Version: ${{ inputs.version }}"
-
-  build:
-    environment: main
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      # https://github.com/docker/login-action#docker-hub
-      - name: Docker login
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
-
-      # hardcoded for now, migrating gh-actions using dockerhub image
-      # has to match action.yaml
-      # - run: echo "version=v3.0.0-beta.2-github"  >> $GITHUB_ENV
-
-      # image version then used by solutions-registry helm chart.
-      - run: pack/build.sh
-        env:
-          PUBLISH: true
-          # VERSION: ${{ env.version }}
-          VERSION: ${{ inputs.version }}
-          IMAGE: docker://cognite/bootstrap-cli
+        echo "Skipping build on main branch"


### PR DESCRIPTION
- hopefully allowing testing from branches
- ci in main branch only logs