### PR TITLE
automatic release failed after

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -91,7 +91,9 @@ jobs:
 
       - name: Create Release
         id: create_release
-        if: steps.check-tag.outputs.match == 'true'
+        # requires >> $GITHUB_OUTPUT
+        # if: steps.check-tag.outputs.match == 'true'
+        if: env.match == 'true'
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- changing `::set-output` to `>> $GITHUB_ENV`
-  simply use GITHUB_ENV with access like `env.match == 'true'`
- using  `steps...outputs...` requires `>> $GITHUB_OUTPUT`
  - recommended for inputs/outputs/needs between *jobs*
  - but not necessarily *steps* where shared GITHUB_ENV is sufficient
- just decide which approach to follow

no semver release required, will be included into next fix/feat