### PR TITLE
fix: make semver working again

### DIFF
--- a/src/bootstrap/__init__.py
+++ b/src/bootstrap/__init__.py
@@ -8,4 +8,4 @@
 # keep manually in sync with pyproject.toml until the above approach is working in Docker too
 # SOLVED: 220419 pa: switched to gh-action semantic-versioning, but still requires manually update here
 # 230301 pa: automated by adding it to pyproject.toml > [tool.semantic_release] > version_variable
-__version__ = "3.0.0"
+__version__ = "3.0.2"


### PR DESCRIPTION
- after v8 problems, back to v7
- but version numbers in init and pyproject differ
- manually aligned